### PR TITLE
Fixed parsing of TID from CMD_0600 response APDU.

### DIFF
--- a/saleSdk/src/main/java/de/lavego/zvt/cmds/CompletionForRegister.java
+++ b/saleSdk/src/main/java/de/lavego/zvt/cmds/CompletionForRegister.java
@@ -41,6 +41,7 @@ public class CompletionForRegister extends Apdu
                 this.tid = Commons.BCDToString(new byte[]{
                         data()[++idx],
                         data()[++idx],
+                        data()[++idx],
                         data()[++idx]
                 });
             }


### PR DESCRIPTION
Based on the ZVT documentation the BMP_29 is 4 bytes long, not just 3. Due to the bug the TID was missing the last 2 characters in the response.